### PR TITLE
Update variables.less and fix window resize bug

### DIFF
--- a/less/bootstrap/variables.less
+++ b/less/bootstrap/variables.less
@@ -301,7 +301,7 @@
 
 // Large screen / wide desktop
 //** Deprecated `@screen-lg` as of v3.0.1
-@screen-lg:                  1200px;
+@screen-lg:                  1450px;
 @screen-lg-min:              @screen-lg;
 //** Deprecated `@screen-lg-desktop` as of v3.0.1
 @screen-lg-desktop:          @screen-lg-min;


### PR DESCRIPTION
Change the breakpoint at which the website is resized for smaller screens. The previous size (1200px) was smaller than the actual width of the website, so there was a point at which the window size would leave elements of the website out, but the website would not resize since it was wider than 1200px. The new breakpoint makes sure that the website is resized before elements start to fall out.